### PR TITLE
Fix genotype wrapping limit problem

### DIFF
--- a/include/gram/evaluation/driver/SingleThreadDriver.h
+++ b/include/gram/evaluation/driver/SingleThreadDriver.h
@@ -14,13 +14,14 @@ namespace gram {
  */
 class SingleThreadDriver : public EvaluationDriver {
 public:
-  SingleThreadDriver(std::unique_ptr<Mapper> mapper, std::unique_ptr<Evaluator> evaluator);
+  SingleThreadDriver(std::unique_ptr<Mapper> mapper, std::unique_ptr<Evaluator> evaluator, bool isMin);
   void evaluate(Individuals& individuals) override;
   virtual void evaluateOne(Individual& individual);
 
 private:
   std::unique_ptr<Mapper> mapper;
   std::unique_ptr<Evaluator> evaluator;
+  bool searchMin;
 };
 }
 

--- a/test/acceptance/evolution_test.cpp
+++ b/test/acceptance/evolution_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE("evolution_test") {
 
   auto evaluator = make_unique<StringDiffEvaluator>("gram");
   auto evaluatorCache = make_unique<EvaluatorCache>(move(evaluator));
-  auto evaluationDriver = make_unique<SingleThreadDriver>(move(mapper1), move(evaluatorCache));
+  auto evaluationDriver = make_unique<SingleThreadDriver>(move(mapper1), move(evaluatorCache), true);
   auto logger = make_unique<NullLogger>();
 
   Evolution evolution(move(evaluationDriver), move(logger));

--- a/test/unit/evaluation/driver/single_thread_driver_test.cpp
+++ b/test/unit/evaluation/driver/single_thread_driver_test.cpp
@@ -38,7 +38,7 @@ TEST_CASE("single thread driver evaluates all individuals in a population", "[si
 
   Individuals individuals({individual1, individual2, individual3});
 
-  SingleThreadDriver driver(move(mapper), move(evaluator));
+  SingleThreadDriver driver(move(mapper), move(evaluator), true);
 
   driver.evaluate(individuals);
 


### PR DESCRIPTION
Fix genotype to phenotype wrapping problem creating invalid inividuals
and stopping evolution process by catching wrappingLimitExceeded
exception and assigning worst possible fitness value. Value of individual is
specified by a boolean variable specifing whether to use minimum or
maximum value of fitness class.

Test cases were updated to reflect new changes in SingleThreadDriver constructor.